### PR TITLE
Updated Village02 Right Blight logic for ER

### DIFF
--- a/EnderLilies.Randomizer/EnderLilies.Randomizer.json
+++ b/EnderLilies.Randomizer/EnderLilies.Randomizer.json
@@ -3330,7 +3330,7 @@
     },
     "Village_02_GAMEPLAY.BP_SCR_LV1S_2100_2": {
       "content": "Generic.i_SpiritCurrencyLv1_S",
-      "rules": "Village02Left + (2LEDGE | silva + dodge | hook +  (LEDGE | claw))"
+      "rules": "(Village02Right | Village02Bottom | Village02Left + (LEDGE | claw)) + (2LEDGE | silva + dodge | hook)"
     },
     "Village_02_GAMEPLAY.BP_WorldTravelVolume_2": {
       "content": "Map.map_village_03.0",


### PR DESCRIPTION
Current logic for this check expects the player to traverse the room from the left, which includes a `(LEDGE | claw)`  requirement, which is needed to get over the pictured gap.
![20240623153839_1](https://github.com/Trexounay/EnderLilies.Archipelago/assets/132797076/f245c5fe-849f-4743-83f2-37b2c584978e)

However, in an entrance randomizer scenario, the player could reasonably enter this room from the bottom or right entrances where no additional movement abilities are required to reach the location of the Stagnant Blights.

This PR reworks the logic to account for players reaching the room from the right or bottom.


